### PR TITLE
fix : could not find method compile()

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -18,7 +18,7 @@ dependencies {
 	// JPA - MySQL 연동
    implementation 'mysql:mysql-connector-java'
    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
-   compile 'mysql:mysql-connector-java'
+   implementation 'mysql:mysql-connector-java'
 }
 
 tasks.named('test') {


### PR DESCRIPTION
backend/build.gradle 의 compile() 함수가 gradle에서 deprecated 되어 build fail이 납니다.

이를 해결하기 위해, compile() 함수를 implementation() 함수로 수정했습니다.